### PR TITLE
Support error handler middlewares

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -81,10 +81,6 @@ export class HyperBunRouter {
     for (let i = 0; i < this.#middlewares.length; i++) {
       const response = await this.#middlewares[i](hyperRequest, context).catch(e => e);
 
-      if (response instanceof Response) {
-        return response;
-      }
-
       if (response instanceof Error) {
         let error = response;
         const relevantErrorMiddlewares = this.#middlewares.slice(i + 1)
@@ -101,7 +97,11 @@ export class HyperBunRouter {
           status: 500,
         });
       }
-    });
+
+      if (response instanceof Response) {
+        return response;
+      }
+    }
 
     const value = await matched.handler(hyperRequest, context);
     return this.#createResponse(value);


### PR DESCRIPTION
This PR adds support for error handler middlewares in express-style syntax.

Notes:
- Since `hyperbun` only accepts registering a single middleware at a time, it might make sense to have them being registered with a different method than `.middleware()` (which this PR does't cover) instead of assuming based on the amount of parameters.
- This PR is a draft and was not tested yet. There's probably typescript issues in there that still need to be addressed.
